### PR TITLE
Remove requirement for whitespace between backticks

### DIFF
--- a/beginner/cogs/code_runner.py
+++ b/beginner/cogs/code_runner.py
@@ -114,7 +114,7 @@ class CodeRunner(Cog):
         color = BLUE
 
         code, user_input = re.match(
-            r"^.*?```(?:py|python)?\s+(.+?)\s+```\s*(.+)?$", content, re.DOTALL
+            r"^.*?```(?:py|python)?\s*(.+?)\s*```\s*(.+)?$", content, re.DOTALL
         ).groups()
 
         out, err, duration = await self.code_runner("exec", code, user_input)
@@ -153,7 +153,7 @@ class CodeRunner(Cog):
             code = content
         else:
             code = re.match(
-                r"^.*?```(?:py|python)?\s+(.+?)\s+```\s*$", content, re.DOTALL
+                r"^.*?```(?:py|python)?\s*(.+?)\s*```\s*$", content, re.DOTALL
             ).group(1)
 
         title = "✅ Formatting - Success"


### PR DESCRIPTION
It was noticed in the server that there was a requirement for whitespace between backticks and the code when using the !exec command and it was raising the following exception, because the check for a code block passed, but then the regex failed to match.

`AttributeError: 'NoneType' object has no attribute 'groups'`

Previously this would not work: `!exec ```print("Hello World")``` `

This change makes the whitespace optional, and should still handle `!exec ```py print("Hello World")``` `